### PR TITLE
Port JDK-8280481 to RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.cpp
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +22,10 @@
  *
  */
 
-#ifndef CPU_RISCV_CODEBUFFER_RISCV_HPP
-#define CPU_RISCV_CODEBUFFER_RISCV_HPP
+#include "precompiled.hpp"
+#include "asm/codeBuffer.inline.hpp"
+#include "asm/macroAssembler.hpp"
 
-private:
-  void pd_initialize() {}
-  bool pd_finalize_stubs();
-
-public:
-  void flush_bundle(bool start_new_bundle) {}
-  static constexpr bool supports_shared_stubs() { return true; }
-
-#endif // CPU_RISCV_CODEBUFFER_RISCV_HPP
+bool CodeBuffer::pd_finalize_stubs() {
+  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
+}

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2267,11 +2267,17 @@ encode %{
         return;
       }
 
-      // Emit stub for static call
-      address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
-        ciEnv::current()->record_failure("CodeCache is full");
-        return;
+      if (CodeBuffer::supports_shared_stubs() && _method->can_be_statically_bound()) {
+        // Calls of the same statically bound method can share
+        // a stub to the interpreter.
+        cbuf.shared_stub_to_interp_for(_method, cbuf.insts()->mark_off());
+      } else {
+        // Emit stub for static call
+        address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
+        if (stub == NULL) {
+          ciEnv::current()->record_failure("CodeCache is full");
+          return;
+        }
       }
     }
   %}

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -28,7 +28,7 @@
  * @bug 8280481
  * @library /test/lib
  *
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64" | os.arch=="riscv64"
  *
  * @run driver compiler.sharedstubs.SharedStubToInterpTest
  */


### PR DESCRIPTION
Follow up [JDK-8280481](https://bugs.openjdk.org/browse/JDK-8280481), other platforms like riscv64 can use it too.
It provides duplicated stubs to interpreter for static calls.

## Testing:

- hotspot/jdk tier1 on unmatched board
- hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java on qemu


## Results
#### Results from [Renaissance 0.14.0](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.14.0)
Note: 'Nmethods with shared stubs' is the total number of nmethods counted during benchmark's run. 'Final # of nmethods' is a number of nmethods in CodeCache when JVM exited.

Because of the current hardware performance limitations and the fact that some cases crash in fastdebug mode (before applying this patch), I selected a few cases to test and reduced the number of iterations using `-r 10`. The data is sufficient to reflect the effect of the optimization.

Thanks to @eastig and @1996scarlet for helping to get the experimental data.
- riscv64
```
+------------------+-------------+----------------------------+---------------------+
|    Benchmark     | Saved bytes | Nmethods with shared stubs | Final # of nmethods |
+------------------+-------------+----------------------------+---------------------+
| future-genetic   |       47824 |                       1278 |                1811 |
| scrabble         |       30616 |                        738 |                1605 |
| fj-kmeans        |       23320 |                        633 |                1386 |
| par-mnemonics    |        2840 |                        621 |                1398 |
| scala-kmeans     |       19544 |                        381 |                1365 |
+------------------+-------------+----------------------------+---------------------+
```